### PR TITLE
Fix the case that labels are all ignored

### DIFF
--- a/pytorch/lovasz_losses.py
+++ b/pytorch/lovasz_losses.py
@@ -220,7 +220,7 @@ def mean(l, ignore_nan=True, empty=0):
     """
     l = iter(l)
     if ignore_nan:
-        l = ifilterfalse(np.isnan, l)
+        l = ifilterfalse(torch.isnan, l)
     try:
         n = 1
         acc = next(l)

--- a/pytorch/lovasz_losses.py
+++ b/pytorch/lovasz_losses.py
@@ -213,14 +213,17 @@ def xloss(logits, labels, ignore=None):
 
 
 # --------------------------- HELPER FUNCTIONS ---------------------------
-
+def isnan(x):
+    return x != x
+    
+    
 def mean(l, ignore_nan=True, empty=0):
     """
     nanmean compatible with generators.
     """
     l = iter(l)
     if ignore_nan:
-        l = ifilterfalse(torch.isnan, l)
+        l = ifilterfalse(isnan, l)
     try:
         n = 1
         acc = next(l)

--- a/pytorch/lovasz_losses.py
+++ b/pytorch/lovasz_losses.py
@@ -174,8 +174,10 @@ def lovasz_softmax_flat(probas, labels, only_present=False):
       labels: [P] Tensor, ground truth labels (between 0 and C - 1)
       only_present: average only on classes present in ground truth
     """
-    if len(probas) == 0:  # if labels are all ignored
-        return np.nan
+    if probas.numel() == 0:
+        # only void pixels, the gradients should be 0
+        return probas * 0.
+    C = probas.size(1)
     
     C = probas.size(1)
     losses = []

--- a/pytorch/lovasz_losses.py
+++ b/pytorch/lovasz_losses.py
@@ -174,6 +174,9 @@ def lovasz_softmax_flat(probas, labels, only_present=False):
       labels: [P] Tensor, ground truth labels (between 0 and C - 1)
       only_present: average only on classes present in ground truth
     """
+    if len(probas) == 0:  # if labels are all ignored
+        return np.nan
+    
     C = probas.size(1)
     losses = []
     for c in range(C):
@@ -211,7 +214,7 @@ def xloss(logits, labels, ignore=None):
 
 # --------------------------- HELPER FUNCTIONS ---------------------------
 
-def mean(l, ignore_nan=False, empty=0):
+def mean(l, ignore_nan=True, empty=0):
     """
     nanmean compatible with generators.
     """


### PR DESCRIPTION
An error occurred in line 177 ( `C = probas.size(1)` ) when input labels are all ignored, because labels got empty.
This PR deal with such problems.

One thing I concerned about is the difference between the lines I added and below lines
```
        if len(labels) == 0:
            # only void pixels, the gradients should be 0
            return logits.sum() * 0.
```

Above is a part of the original implementation of lovasz_flat. This doesn't exclude void labels for calculation the loss. Is it excepted behavior?
